### PR TITLE
Run the binding generator container as the invoking user

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -31,7 +31,12 @@ API_VERSION="$(api_version)"
 SWAGGER_SPEC="$(swagger_spec "$API_VERSION")"
 DOCKER_IMAGE="$(docker build -q .)"
 
+# Run as the invoking user so generated files and directories (e.g. test/) are
+# owned by us and can be cleaned up afterwards. Without this the container runs
+# as root and the post-generation cleanup fails on Linux/CI runners.
 docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
     -e PKG_VERSION="$PKG_VERSION" \
     -e GO_POST_PROCESS_FILE="gofmt -w" \
     -v "$SWAGGER_SPEC":/tmp/swagger_spec \


### PR DESCRIPTION
The **Update API bindings** workflow has failed on every run since it was added ([latest run](https://github.com/cloudsmith-io/cloudsmith-api-go/actions/runs/30520919700)):

```
removed '.travis.yml'
removed 'git_push.sh'
rm: cannot remove 'test/api_user_test.go': Permission denied
rm: cannot remove 'test/api_vulnerabilities_test.go': Permission denied
...
[generate] ERROR task failed
```

## Cause

`bin/generate` runs `openapitools/openapi-generator-cli` as root with the repo bind-mounted at `/local`. Directories that already exist in the repo (`docs/`, `api/`) stay owned by the checkout user, so root-owned files inside them can still be replaced — but `test/` is created *by the container*, so on Linux it lands root-owned. The post-generation `rm -rfv test/` runs on the host as the unprivileged `runner` user, which has no write permission on that directory and therefore cannot unlink its contents.

macOS Docker Desktop maps bind-mount ownership onto the host user regardless of the container uid, which is why this never reproduced for local runs and only broke in CI.

## Fix

Pass `--user "$(id -u):$(id -g)"` so generated files and directories are owned by the invoking user, plus `HOME=/tmp` since the mapped uid has no home directory in the image.

## Verification

- `./bin/generate` run locally with the change: generator completes, `test/` is removed cleanly, `go build ./...` passes.
- Generated output is identical to the committed bindings apart from the API version header (`1.1288.1` → `1.1321.5`) and one `maxLength` spec change — the change does not affect generation itself.
- Confirmed the image's entrypoint does not re-escalate: `id` inside the container reports the mapped uid, and files it creates carry that uid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)