### PR TITLE
add signing to workflow

### DIFF
--- a/.github/workflows/update-bindings.yml
+++ b/.github/workflows/update-bindings.yml
@@ -92,6 +92,7 @@ jobs:
         with:
           branch: automated/update-bindings-v${{ steps.versions.outputs.new_version }}
           base: master
+          sign-commits: true
           title: "Update Go API bindings to version ${{ steps.versions.outputs.new_version }}"
           commit-message: "Update Go API bindings to version ${{ steps.versions.outputs.new_version }}"
           body: |


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow to improve commit authenticity. The workflow now signs commits made during the automated update of Go API bindings.

* [`.github/workflows/update-bindings.yml`](diffhunk://#diff-177ffb7a8f2afa3f4f7cb8afe7017d18f76111292ad70b75b5eb98b80510d988R95): Added the `sign-commits: true` option to ensure that automated commits are GPG-signed.